### PR TITLE
Ignore @2x.png files for filename linting

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -5,7 +5,10 @@
       "type": "chmod"
     },
     "filename": {
-      "type": "filename"
+      "type": "filename",
+      "exclude": [
+        "(.*@2x\\.png$)"
+      ]
     },
     "jshint": {
       "type": "jshint",


### PR DESCRIPTION
These files are flagged as an error for filename linting yet we use them for retina high resolution images.