### PR TITLE
Added JPEG files (.jpg, .jpeg and .gif) to the list of filenames allowed '@2x' filenames.

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -7,7 +7,7 @@
     "filename": {
       "type": "filename",
       "exclude": [
-        "(.*@2x\\.png$)"
+        "(.*@2x\\.(png|jpg|jpeg|gif)$)"
       ]
     },
     "jshint": {


### PR DESCRIPTION
Title says it all.