### PR TITLE
Remove ID selector warning for SCSS.

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -55,7 +55,7 @@ linters:
     enabled: true
 
   IdSelector:
-    enabled: true
+    enabled: false
 
   ImportantRule:
     enabled: false


### PR DESCRIPTION
I just don't think this is a good rule to have turned on. We use ID selectors in a lot of places.