### PR TITLE
Improve SCSS lint configuration

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -23,7 +23,7 @@ linters:
     enabled: true
 
   DeclarationOrder:
-    enabled: true
+    enabled: false
 
   DuplicateProperty:
     enabled: true


### PR DESCRIPTION
This rule was preventing us to use `@include` SASS declarations without lint errors. This is a really common use case, for example, for breakpoint mixins:

```
@include breakpoint(belowTablet) {
  display: block;
}
```

If I check this code with the linter I get:

```
  Warning  (DeclarationOrder) SCSS-Lint
    Expected item on line 155 to appear before line 141. Rule sets should be
    ordered as follows: `@extends`, `@includes` without `@content`,
    properties, `@includes` with `@content`, nested rule sets

             152     }
             153
             154     // Responsive
    >>>      155     @include breakpoint(belowTablet) {
             156       display: block;
             157     }
```

That's the reason I want to disable this lint option