### PR TITLE
Remove `md` from text linter & Improve docs

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -53,7 +53,7 @@
     },
     "text": {
       "type": "text",
-      "include" : "(\\.(txt|md|html|haml?)$)",
+      "include" : "(\\.(txt|html|haml?)$)",
       "text.max-line-length": 100
     },
     "ruby": {

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project provides some useful extensions for [Arcanist](https://github.com/p
 - [TAP Test Engine](#tap_test_engine)
 - [SCSS-Lint Linter](#scss_lint_linter)
 - [ESlint Linter](#eslint_linter)
+- [markdownlint Linter](#markdownlint_linter)
 
 ## Installation
 
@@ -193,27 +194,22 @@ Below is an example of an `.arclint` file that includes the ESlint Linter:
 }
 ```
 
+### `markdownlint_linter`
+
+This extension will lint your project using [markdownlint](https://github.com/markdownlint/markdownlint). It is important to mention that the extension won't install mdl, so you must do it manually (`gem install mdl`). Just make sure you have the `mdl` executable listed on your `$PATH`.
+
+Below is an example of an `.arclint` file that includes the markdownlint Linter:
+
+```json
+{
+  "linters": {
+    "markdown": {
+      "type": "markdownlint",
+      "include": "/\\.(md|markdown)/",
+      "mdl.config": ".mdlrc.cfg"
+    }
+  }
+}
+```
+
 For more information regarding Arcanist linters configuration, access the [Arcanist Lint User Guide](https://secure.phabricator.com/book/phabricator/article/arcanist_lint/).
-
-(The MIT License)
-
-Copyright (c) 2015 Tagview Tecnologia <team@tagview.com.br>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/adding_linting.md
+++ b/adding_linting.md
@@ -7,15 +7,15 @@ How to add linting to a new bitnami project.
 We keep everything arc-related inside this repo and just
 share it with all of our projects.
 
-```
-git submodule add git@github.com:Bitnami/arcanist-extensions.git .arcanist-extensions
+```shell
+git submodule add git@github.com:bitnami/arcanist-extensions.git .arcanist-extensions
 ```
 
 ## Load extensions
 
-You need to tell arc to load the extensions in the .arcconfig
+You need to tell arc to load the extensions in the `.arcconfig`
 
-```
+```json
 {
   "phabricator.uri" : "http://phabricator.bitnami.com:8080/",
   "project.name" : "Awesome bitnami project",
@@ -31,11 +31,12 @@ are loading all required extensions in this file.
 
 ## Symlink lint files
 
-From the home directory symlink all lint files from .arcanist-extensions.
+From the home directory symlink all lint files from `.arcanist-extensions`.
 
-```
+```shell
 ln -fsv .arcanist-extensions/.jshintrc . &&
 ln -fsv .arcanist-extensions/.scss-lint.yml . &&
 ln -fsv .arcanist-extensions/.rubocop.yml . &&
+ln -fsv .arcanist-extensions/.mdlrc.cfg . &&
 ln -fsv .arcanist-extensions/.arclint .
 ```

--- a/configuring_lints.md
+++ b/configuring_lints.md
@@ -17,8 +17,6 @@ Open a ruby file and write it straight away. If the file has
 any rubocop offenses it should display arrows in the gutter.
 See the syntastic docs for examples.
 
-
 ## Emacs
 
 ## Sublime
-


### PR DESCRIPTION
 - Remove md file type from text editor because some of the rules has no sense in this kind of files
 - Fix typos and improve the existing docs such as README