### PR TITLE
Allow HAML files to reach 120 character per line

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -53,8 +53,13 @@
     },
     "text": {
       "type": "text",
-      "include" : "(\\.(txt|html|haml?)$)",
+      "include" : "(\\.(txt|html)$)",
       "text.max-line-length": 100
+    },
+    "haml": {
+      "type": "text",
+      "include" : "(\\.(haml?)$)",
+      "text.max-line-length": 120
     },
     "ruby": {
       "type": "rubocop",


### PR DESCRIPTION
HAML files are hard to change to conform to shorter lines. And nowadays 120 characters is not than long on most User Interfaces.

For other text files I keep the preferable shorter lines at 100.