### PR TITLE
Avoid rubocop complains for a comment header in all files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -985,3 +985,6 @@ Rails/TimeZone:
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
Gets rid of:

```bash
$ arc lint
...
   Warning  (Style/FrozenStringLiteralComment) RuboCop
    Style/FrozenStringLiteralComment: Missing magic comment `#
    frozen_string_literal: true`.

    >>>        1 module blah
```