### PR TITLE
Allow eslint linter to enable the --fix flag to apply autofixable rules

### DIFF
--- a/eslint_linter/src/ArcanistESLintLinter.php
+++ b/eslint_linter/src/ArcanistESLintLinter.php
@@ -3,6 +3,7 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
 
   private $eslintenv;
   private $eslintconfig;
+  private $eslintautofix;
 
   public function getInfoName() {
     return 'ESLint';
@@ -52,6 +53,10 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
         'type' => 'optional string',
         'help' => pht('config file to use the default is .eslint.'),
       ),
+      'eslint.autofix' => array(
+        'type' => 'optional string',
+        'help' => pht('runs the command line with --fix to apply autofixable rules.'),
+      ),
     );
     return $options + parent::getLinterConfigurationOptions();
   }
@@ -63,6 +68,9 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
       return;
     case 'eslint.eslintconfig':
       $this->eslintconfig = $value;
+      return;
+    case 'eslint.autofix':
+      $this->eslintautofix = $value;
       return;
     }
     return parent::setLinterConfigurationValue($key, $value);
@@ -81,6 +89,11 @@ final class ArcanistESLintLinter extends ArcanistExternalLinter {
     if ($this->eslintconfig) {
       $options[] = '--config='.$this->eslintconfig;
     }
+
+    if ($this->eslintautofix) {
+      $options[] = '--fix';
+    }
+
     $options = array_merge($options, array('--quiet'));
     return $options;
   }


### PR DESCRIPTION
The `--fix` flag allows `eslint` to apply autofixable rules. This is useful when working with `prettier`. To avoid conflicts between `prettier` and `eslint`, they have created a plugin/config called [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier). 

Currently, we've some projects using both prettier and eslint linters. If we enable this plugin and run `arc lint`, both commands will refer to the same information:

1. Eslint detects the issue and says it's autofixable
1. Prettier asks you to apply the autofix

``` Auto-Fix  (PRETTIER) Prettier Format
    This file has not been prettier-ified

               1 const path = require("path");
               2 const merge = require("webpack-merge");
               3 const webpack = require("webpack");
               4 const common = require("./webpack.common");
               5
               6 module.exports = merge(common, {
               7   mode: "development",
               8   output: {
               9     // Cache the assets between builds to speed up the build process
              10     filename: "[name].[chunkhash:8].js",
    >>> -     11     chunkFilename: "[name].[chunkhash:8].js",
        -     12   },
        -     13   devtool: "eval-source-map",
        -     14   plugins: [
        -     15     new webpack.DefinePlugin({
        -     16       "process.env.NODE_ENV": '"development"',
        -     17     }),
        +            chunkFilename: "[name].[chunkhash:8].js"
        +          },
        +          devtool: "eval-source-map",
        +          plugins: [
        +            new webpack.DefinePlugin({
        +              "process.env.NODE_ENV": '"development"'
        +            })
              18   ],
              19   devServer: {

   Error  (ESLINT) ESLINT
    11:45 error Delete `,` prettier/prettier

               8   output: {
               9     // Cache the assets between builds to speed up the build process
              10     filename: "[name].[chunkhash:8].js",
    >>>       11     chunkFilename: "[name].[chunkhash:8].js",
              12   },
              13   devtool: "eval-source-map",
              14   plugins: [
```

To avoid it, we can just let `eslint` autofix `prettier` rules. For that reason, I've added a new config option in the linter to enable the `--fix` flag.