### PR TITLE
Disabling excessive rubocop rules.

### DIFF
--- a/.rubocop.0.71.yml
+++ b/.rubocop.0.71.yml
@@ -771,7 +771,7 @@ Metrics/PerceivedComplexity:
   Description: >-
                  A complexity metric geared towards measuring complexity for a
                  human reader.
-  Enabled: false
+  Enabled: true
 
 #################### Lint ################################
 ### Warnings

--- a/.rubocop.0.71.yml
+++ b/.rubocop.0.71.yml
@@ -731,6 +731,10 @@ Metrics/AbcSize:
                  branches, and conditions.
   Enabled: false
 
+Metrics/BlockLength:
+  Description: 'Avoid blocks longer than 25 lines of code.'
+  Enabled: false
+
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
@@ -738,7 +742,7 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
-  Enabled: true
+  Enabled: false
 
 Metrics/CyclomaticComplexity:
   Description: >-
@@ -767,7 +771,7 @@ Metrics/PerceivedComplexity:
   Description: >-
                  A complexity metric geared towards measuring complexity for a
                  human reader.
-  Enabled: true
+  Enabled: false
 
 #################### Lint ################################
 ### Warnings


### PR DESCRIPTION
I think we never respect those rules.
Every time we violate one of them, we just disable it in-code to have a green phabricator build.