### PR TITLE
Fix no-op `continue` in TAPTestEngine switch statement

### DIFF
--- a/tap_test_engine/src/TAPTestEngine.php
+++ b/tap_test_engine/src/TAPTestEngine.php
@@ -47,7 +47,7 @@ final class TAPTestEngine extends ArcanistUnitTestEngine {
           break;
 
         default:
-          continue;
+          continue 2;
       }
 
       $results[] = $result;


### PR DESCRIPTION
`arc unit` failed locally with the following error: `Error while loading file
".../tap_test_engine/src/TAPTestEngine.php": "continue" targeting switch is
equivalent to "break". Did you mean to use "continue 2"?` It's almost certainly a difference in local setup, however ...

It seems the intention was to escape from the `foreach` iteration. However, a plain
`default: continue` in a `switch` is effectively a no-op. 2 levels should continue the `foreach`.